### PR TITLE
Adding ability to load Great Vault from the Rated PVP Screen

### DIFF
--- a/GreatVaultViewer.lua
+++ b/GreatVaultViewer.lua
@@ -91,6 +91,7 @@ function addon:EventHandler(event, arg1 )
 		tinsert(UISpecialFrames, WeeklyRewardsFrame:GetName())
 	elseif event == "ADDON_LOADED" and arg1 == "Blizzard_PVPUI" then 
 		PVPQueueFrame.HonorInset.CasualPanel.WeeklyChest:SetScript("OnMouseDown", function() addon:ToggleVault() end)
+		PVPQueueFrame.HonorInset.RatedPanel.WeeklyChest:SetScript("OnMouseDown", function() addon:ToggleVault() end)
 	elseif event == "ADDON_LOADED" and arg1 == "Blizzard_ChallengesUI" then 
 		ChallengesFrame.WeeklyInfo.Child.WeeklyChest:SetScript("OnMouseDown", function() addon:ToggleVault() end)
 	end


### PR DESCRIPTION
Hi!

Great Addon and something I'm surprised Blizzard didn't think of!

I just noticed that you're unable to load the Great Vault by clicking the GV icon within the Rated PVP tab (only the "Quick Match" PVP Tab). This PR just fixes that to have the same functionality across both PVP tabs.

Happy for you to make changes if needed.

Thanks!